### PR TITLE
.env: remove invalid whitespaces in JRNL_DIR variable

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,3 @@
 # GENERAL
 PYTHONDONTWRITEBYTECODE=1
-JRNL_DIR = "./examples/jrnl-dir/"
+JRNL_DIR="./examples/jrnl-dir/"


### PR DESCRIPTION
replace `JRNL_DIR = "` with `JRNL_DIR="`