### PR TITLE
5 Implement get_file_path_by_month

### DIFF
--- a/src/client/local_client.py
+++ b/src/client/local_client.py
@@ -32,12 +32,9 @@ class LocalClient:
 
         files = []
         for file in os.listdir(files_path):
-            if file.endswith(".txt"):
-                files.append(os.path.join(files_path, file))
+            files.append(os.path.join(files_path, file))
 
         number_of_files = len(files)
-        self._check_files_exist(files_path, number_of_files)
-
         LOGGER.info(
             f"We find {number_of_files} files in the following path: {files_path}",
             extra={"month_path": files_path, "number_of_files": number_of_files},
@@ -45,8 +42,16 @@ class LocalClient:
         files.sort()
         return files
 
-    def get_jrnl_files_path_by_month(self, month: int) -> List[str]:
-        raise NotImplementedError
+    def get_jrnl_files_path_by_month(self, month: int, year: int = datetime.now().year) -> List[str]:
+        all_files = self.get_file_paths_by_month(month=month, year=year)
+        jrnl_files = list(filter(lambda file: file.endswith(".txt"), all_files))
+        number_of_files = len(jrnl_files)
+        self._check_files_exist(files_path=jrnl_files, number_of_files=number_of_files)
+        LOGGER.info(
+            f"We find {number_of_files} jrnl files for year: {year} month: {month}",
+            extra={"month": month, "year": year, "number_of_files": number_of_files},
+        )
+        return jrnl_files
 
     def get_monthly_habits_by_month(self, month: int) -> List[str]:
         raise NotImplementedError

--- a/tests/unit/client/test_local_client.py
+++ b/tests/unit/client/test_local_client.py
@@ -11,13 +11,21 @@ def test_get_file_paths_by_month():
 
     # THEN
     april_2025_files = client.get_file_paths_by_month(month=month)
-    assert len(april_2025_files) == 30
+    assert len(april_2025_files) == 32
 
     # GIVEN
     month = 12
     year = 2024
     december_2024_files = client.get_file_paths_by_month(month=month, year=year)
     assert len(december_2024_files) == 31
+
+    # GIVEN
+    month = 11
+    year = 2024
+
+    # THEN
+    november_2024_files = client.get_file_paths_by_month(month=month, year=year)
+    assert len(november_2024_files) == 1
 
 
 def test_get_file_paths_by_month_error():
@@ -30,13 +38,18 @@ def test_get_file_paths_by_month_error():
     with pytest.raises(LocalClientError):
         client.get_file_paths_by_month(month=month)
 
+
+def test_get_jrnl_files_path_by_month():
+    client = LocalClient()
+
     # GIVEN
-    month = 11
-    year = 2024
+    month = 4
 
     # THEN
-    with pytest.raises(LocalClientError):
-        client.get_file_paths_by_month(month=month, year=year)
+    april_2025_files = client.get_jrnl_files_path_by_month(month=month)
+    assert len(april_2025_files) == 30
+
+
 
 def test__check_path_exist():
     client = LocalClient()


### PR DESCRIPTION
- Remove .csv check from `get_file_paths_by_month`
- Fix tests to take into account other file types
- Implement `get_jrnl_files_path_by_month`
- Test `get_jrnl_files_path_by_month`